### PR TITLE
Step4

### DIFF
--- a/src/main/kotlin/io/hhplus/cleanarchitecture/api/lecture/facade/ApplicationFacade.kt
+++ b/src/main/kotlin/io/hhplus/cleanarchitecture/api/lecture/facade/ApplicationFacade.kt
@@ -23,18 +23,17 @@ class ApplicationFacade(
             throw CoreApiException(ErrorCode.LECTURE_NOT_FOUND)
         }
 
-        // 신청 여부 검증
-        if (applicationService.isExistBy(lectureId, userId)) {
-            throw CoreApiException(ErrorCode.ALREADY_APPLIED)
-        }
-
         // 신청 정원 검증
         val lecture = lectureService.getByIdWithLock(lectureId)
         if (!lecture.isAvailableApply()) {
             throw CoreApiException(ErrorCode.CAPACITY_EXCEEDED)
         }
-
         lecture.incrementApplyCount()
+
+        // 신청 여부 검증
+        if (applicationService.isExistBy(lectureId, userId)) {
+            throw CoreApiException(ErrorCode.ALREADY_APPLIED)
+        }
 
         val applicationLecture = applicationService.createApplication(userId, lectureId)
         return ApplyLectureResult(

--- a/src/main/kotlin/io/hhplus/cleanarchitecture/domain/lecture/ApplicationService.kt
+++ b/src/main/kotlin/io/hhplus/cleanarchitecture/domain/lecture/ApplicationService.kt
@@ -2,6 +2,7 @@ package io.hhplus.cleanarchitecture.domain.lecture
 
 import io.hhplus.cleanarchitecture.domain.lecture.model.LectureApplication
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Isolation
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 

--- a/src/test/kotlin/io/hhplus/cleanarchitecture/api/lecture/facade/ApplicationFacadeTest.kt
+++ b/src/test/kotlin/io/hhplus/cleanarchitecture/api/lecture/facade/ApplicationFacadeTest.kt
@@ -128,5 +128,30 @@ class ApplicationFacadeTest(
             assertThat(successCount.get()).isEqualTo(30)
             assertThat(errorCount.get()).isEqualTo(10)
         }
+
+        @Test
+        fun `동일한 유저 정보로 같은 특강을 동시에 5번 신청하더라도 한 번만 성공해야 한다`() {
+            // given
+            val userId = 1L
+            val lecture = lectureRepository.save(TestFixtureUtils.lecture())
+            val successCount = AtomicInteger()
+            val errorCount = AtomicInteger()
+
+            val action = Runnable {
+                try {
+                    applicationFacade.apply(userId, lecture.id)
+                    successCount.incrementAndGet()
+                } catch (e: Exception) {
+                    errorCount.incrementAndGet()
+                }
+            }
+
+            // when
+            ConcurrencyTestUtils.executeConcurrently(5, action)
+
+            // then
+            assertThat(successCount.get()).isEqualTo(1)
+            assertThat(errorCount.get()).isEqualTo(4)
+        }
     }
 }


### PR DESCRIPTION
### **커밋 링크**
- [refactor: 같은 사용자가 동일한 특강에 대해 신청 성공하지 못하도록 개선](https://github.com/DevCHW/hhplus-cleanarchitecture/commit/9c200dc0840c87884e0d998571c6df4b9916ff0c)

- [test: 동일한 유저 정보로 같은 특강을 5번 신청했을 때, 1번만 성공하는 것을 검증하는 통합 테스트 작성](https://github.com/DevCHW/hhplus-cleanarchitecture/commit/9bd06546d2a8b5f775073745cfa9cc225ae6881f)

해당 PR 이후 데드락 문제가 발생하는 것을 확인하여 해결한 뒤 아래의 PR을 추가했습니다. PR 재오픈 방법을 몰라 링크 첨부합니다.
- PR 링크 : https://github.com/DevCHW/hhplus-cleanarchitecture/pull/4
- 커밋 링크 : [fix: 전파속성 변경으로 인한 데드락 문제 해결](https://github.com/DevCHW/hhplus-cleanarchitecture/pull/4/commits/9d01e1507b631b71da987c1cfb592fbbe1560d4f)


---
같은 사용자가 동일한 특강에 대해 신청 성공하지 못하도록 하기 위한 방법으로 처음에는 lecture_application 테이블에 user_id, lecture_id로 복합 유니크 제약조건을 걸어 요청을 실패 시키는 방법을 생각했습니다.

그러나 유니크 제약 조건을 걸어서 요청을 데이터베이스를 통해 실패시키고 코드 레벨에서 예외를 핸들링하려면 `DataIntegrityViolationException`에 대해서 명시적으로 처리해야하는데, 해당 예외는 꼭 유니크 제약 조건 위반에 대해서만 발생하는 예외가 아니기에 잘못 처리했을 경우 추적이 힘든 문제가 발생할 여지가 있다고 생각했습니다.

그래서 아래의 코드 스니펫과 같이 Lock을 점유하는 동안 신청 여부를 조회하여 검증 하였는데, 이렇게 할 경우에는 Lock 점유 시간이 길어져 병목 구간이 늘어나게 됩니다.

단순한 select 쿼리 하나이기에 병목 구간이 심각하게 늘어나는 것은 아니지만 코치님의 관점에서는 어떤 방법이 더 괜찮아 보이는지, 혹은 이러한 상황 속 또다른 해결책이 있으실지 견해가 궁금합니다

```
// ApplicationFacade.kt
/**
 * 특강 신청
 */
@Transactional(isolation = Isolation.READ_COMMITTED)
fun apply(userId: Long, lectureId: Long): ApplyLectureResult {
    // ...

    // 신청 정원 검증
    val lecture = lectureService.getByIdWithLock(lectureId) // Pessimistic Lock

    // ...

    // 신청 여부 검증
    if (applicationService.isExistBy(lectureId, userId)) {
        throw CoreApiException(ErrorCode.ALREADY_APPLIED)
    }

    // ...
}

// ApplicationService.kt
/**
 * 특강 신청 존재 여부 조회
 */
@Transactional(readOnly = true) 
fun isExistBy(lectureId: Long, userId: Long): Boolean {
    return applicationRepository.isExistBy(lectureId, userId)
}
```
---
### **이번주 KPT 회고**

### Keep
- 애매한 기준들에 대해서 명확하게 정의내리고자 한 점

### Problem
- 과제를 몰아서 해서 피곤했음

### Try
- 클린 아키텍처 정독