### PR TITLE
fix: 전파속성 변경으로 인한 데드락 문제 해결

### DIFF
--- a/src/main/kotlin/io/hhplus/cleanarchitecture/api/lecture/facade/ApplicationFacade.kt
+++ b/src/main/kotlin/io/hhplus/cleanarchitecture/api/lecture/facade/ApplicationFacade.kt
@@ -6,6 +6,7 @@ import io.hhplus.cleanarchitecture.api.lecture.facade.dto.result.ApplyLectureRes
 import io.hhplus.cleanarchitecture.domain.lecture.ApplicationService
 import io.hhplus.cleanarchitecture.domain.lecture.LectureService
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Isolation
 import org.springframework.transaction.annotation.Transactional
 
 @Component
@@ -16,7 +17,7 @@ class ApplicationFacade(
     /**
      * 특강 신청
      */
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     fun apply(userId: Long, lectureId: Long): ApplyLectureResult {
         // 특강 존재 여부 검증
         if (!lectureService.isExist(lectureId)) {

--- a/src/main/kotlin/io/hhplus/cleanarchitecture/domain/lecture/ApplicationService.kt
+++ b/src/main/kotlin/io/hhplus/cleanarchitecture/domain/lecture/ApplicationService.kt
@@ -36,7 +36,7 @@ class ApplicationService(
     /**
      * 특강 신청 존재 여부 조회
      */
-    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
+    @Transactional(readOnly = true)
     fun isExistBy(lectureId: Long, userId: Long): Boolean {
         return applicationRepository.isExistBy(lectureId, userId)
     }


### PR DESCRIPTION
전파 속성 변경으로 하나의 스레드가 Connection을 두개 이상 점유하도록 했더니 데드락이 발생함.
전파 속성 변경 대신 격리수준 변경으로 해결

참고
https://techblog.woowahan.com/2664/